### PR TITLE
Move globby to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "bugs": "https://github.com/oclif/config/issues",
   "dependencies": {
     "debug": "^3.1.0",
+    "globby": "^8.0.1",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
@@ -21,7 +22,6 @@
     "@types/wrap-ansi": "^3.0.0",
     "chai": "^4.1.2",
     "fancy-test": "^1.2.0",
-    "globby": "^8.0.1",
     "lodash": "^4.17.10",
     "mocha": "^5.2.0",
     "ts-node": "^7.0.0",


### PR DESCRIPTION
We ran into a "module not found" error after publishing our CLI. Turned out that we have `@oclif/dev-cli` as a devDep and that depends on globby as well. This means that tests won't catch this and only a published module will fail.

I did notice that globby is being resolved relative to the "root" in addition to `__dirname` but couldn't figure out why that'd be necessary based on any of the commit messages. 