### PR TITLE
fix: tsconfig.json should be respected by ts-node

### DIFF
--- a/src/ts_node.ts
+++ b/src/ts_node.ts
@@ -38,16 +38,10 @@ function registerTSNode(root: string) {
   try {
     process.chdir(root)
     tsNode.register({
-      skipProject: true,
-      transpileOnly: true,
-      // cache: false,
-      // typeCheck: true,
+      typeCheck: true,
       compilerOptions: {
-        target: tsconfig.compilerOptions.target || 'es2017',
-        module: 'commonjs',
-        sourceMap: true,
         rootDirs,
-        typeRoots,
+        typeRoots
       }
     })
   } finally {


### PR DESCRIPTION
I spent a few hours today trying to figure out why the code generated by `tsc` did not match code being generated when I ran my commands. Eventually, I figured out that my tsconfig.json file was ignored when running the command. This was quite frustrating.

I suspect there may have been a historical reason for ignoring the tsconfig.json, like before d120ec1, it may not have been found correctly, but everything seems to work as expected for my project by letting ts-node load the project config.