### PR TITLE
feat: use esModuleInterop when defined (fixes #179)

### DIFF
--- a/src/ts-node.ts
+++ b/src/ts-node.ts
@@ -17,6 +17,7 @@ export interface TSConfig {
     rootDirs?: string[]
     outDir?: string
     target?: string
+    esModuleInterop?: boolean;
   }
 }
 
@@ -43,6 +44,7 @@ function registerTSNode(root: string) {
       // cache: false,
       // typeCheck: true,
       compilerOptions: {
+        esModuleInterop: tsconfig.compilerOptions.esModuleInterop,
         target: tsconfig.compilerOptions.target || 'es2017',
         module: 'commonjs',
         sourceMap: true,

--- a/test/ts-node.test.ts
+++ b/test/ts-node.test.ts
@@ -1,0 +1,70 @@
+import * as path from 'path'
+import * as tsNode from 'ts-node'
+
+import {TSConfig} from '../src/ts-node'
+import * as util from '../src/util'
+
+import {expect, fancy} from './test'
+
+const root = path.resolve(__dirname, 'fixtures/typescript')
+const orig = 'src/hooks/init.ts'
+let tsNodeRegisterCallArguments: any[] = []
+
+/**
+ * Delete a module from the require cache before requiring it.
+ */
+export default function freshRequire(name: string) {
+  delete require.cache[require.resolve(name)]
+  return require(name)
+}
+
+const DEFAULT_TS_CONFIG: TSConfig = {
+  compilerOptions: {}
+}
+
+const withMockTsConfig = (config: TSConfig = DEFAULT_TS_CONFIG) =>
+  fancy
+    .stub(tsNode, 'register', (arg: any) => {
+      tsNodeRegisterCallArguments.push(arg)
+    })
+    .stub(util, 'loadJSONSync', (arg: string) => {
+      if (arg.endsWith('tsconfig.json')) {
+        return config
+      }
+    })
+    .finally(() => {
+      tsNodeRegisterCallArguments = []
+    })
+
+describe('tsPath', () => {
+  withMockTsConfig()
+    .it('should resolve a .ts file', () => {
+      const {tsPath} = freshRequire('../src/ts-node')
+      const result = tsPath(root, orig)
+      expect(result).to.equal(path.join(root, orig))
+    })
+
+  withMockTsConfig()
+    .it('should leave esModuleInterop undefined by default', () => {
+      const {tsPath} = freshRequire('../src/ts-node')
+      tsPath(root, orig)
+      expect(tsNodeRegisterCallArguments.length).is.equal(1)
+      expect(tsNodeRegisterCallArguments[0])
+        .to.have.nested.property('compilerOptions.esModuleInterop')
+        .equal(undefined)
+    })
+
+  withMockTsConfig({
+    compilerOptions: {
+      esModuleInterop: true
+    }
+  })
+    .it('should use the provided esModuleInterop option', () => {
+      const {tsPath} = freshRequire('../src/ts-node')
+      tsPath(root, orig)
+      expect(tsNodeRegisterCallArguments.length).is.equal(1)
+      expect(tsNodeRegisterCallArguments[0])
+        .to.have.nested.property('compilerOptions.esModuleInterop')
+        .equal(true)
+    })
+})


### PR DESCRIPTION
Fixes https://github.com/oclif/oclif/issues/179.

* Added `esModuleInterop` to `TSConfig`.
* Added `ts-node.test.ts`

This pull request updates `ts-node.ts` to use the `esModuleInterop` of loaded `tsconfig.json` files. It should now be possible to write oclif-based CLIs in TypeScript projects with `esModuleInterop` set to true.