### PR TITLE
fix: made command not found error message more explicit

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -178,7 +178,7 @@ export class Plugin implements IPlugin {
       return cmd
     }
     const cmd = fetch()
-    if (!cmd && opts.must) error(`command ${id} not found`)
+    if (!cmd && opts.must) error(`command ${id} file found, but without an implementation`)
     return cmd
   }
 


### PR DESCRIPTION
I had several commands that I had been working on over several days and happened to comment out the body of one of them. Days later I ran `oclif-dev manifest`, and received an error: 
`Error Plugin: cli: command transform not found`
Which because the command was called `transform`, it had me thinking it had to do with some internal oclif transformation and I headed down all sorts of rabbit trails before I realized I needed to uncomment my implementation. ;-)
I think this is the only way this error can be thrown, so I think it can be this specific. I also thought about changing the id to the relative command path for more clarity, but decided to keep it simple.
This simple change in the error message might help the next person.
Let me know your thoughts.
Thanks.
