### PR TITLE
Exploration: space-separated subcommands

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -146,7 +146,7 @@ export class Plugin implements IPlugin {
       const p = path.parse(file)
       const topics = p.dir.split('/')
       let command = p.name !== 'index' && p.name
-      return [...topics, command].filter(f => f).join(':')
+      return [...topics, command].filter(f => f).join(' ')
     })
     this._debug('found commands', ids)
     return ids
@@ -162,7 +162,7 @@ export class Plugin implements IPlugin {
         if (cmd.default && cmd.default.run) return cmd.default
         return Object.values(cmd).find((cmd: any) => typeof cmd.run === 'function')
       }
-      const p = require.resolve(path.join(this.commandsDir, ...id.split(':')))
+      const p = require.resolve(path.join(this.commandsDir, ...id.split(' ')))
       this._debug('require', p)
       let m
       try {


### PR DESCRIPTION
b9775af shows how to possibly make `commandIDs` return space-separated commands (`user add`) instead of colon-separated (`user:add`).

I opened this PR to gather feedback how to best do it. Can it be achieved without modifying `plugin.ts`? Should it be configurable via `package.json` like this?

```json
{
  "oclif": {
    "commandSeparator": " "
  }
}
```

Related:

- Support for space-separated subcommands https://github.com/oclif/oclif/issues/186
- PR in @oclif/command: https://github.com/oclif/command/pull/51