### PR TITLE
Allow acl in S3 interface

### DIFF
--- a/src/pjson.ts
+++ b/src/pjson.ts
@@ -42,6 +42,7 @@ export namespace PJSON {
   }
 
   export interface S3 {
+    acl?: string
     bucket?: string
     host?: string
     xz?: boolean


### PR DESCRIPTION
Companion PR to https://github.com/oclif/dev-cli/pull/79

Exposes `acl` property in the S3 interface that can be used to specify a custom ACL when uploading the packed CLI.