### PR TITLE
Lazy require 'typescript' module.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@types/indent-string": "^3.2.0",
     "@types/lodash": "^4.14.120",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.12.19",
+    "@types/node": "^10.12.20",
     "@types/proxyquire": "^1.3.28",
     "@types/wrap-ansi": "^3.0.0",
     "chai": "^4.2.0",

--- a/src/ts-node.ts
+++ b/src/ts-node.ts
@@ -5,12 +5,10 @@ import * as TSNode from 'ts-node'
 import Debug from './debug'
 const debug = Debug()
 
-let parseConfigFileTextToJson: any = null
+let typescript: typeof import('typescript')
 try {
-  // Lazy-require 'typescript' to support JavaScript @oclif projects.
-  ({parseConfigFileTextToJson} = require('typescript'))
+  typescript = require('typescript')
 } catch (ex) {
-  // Ignore errors
   debug('Cannot find typescript', ex)
 }
 
@@ -67,8 +65,8 @@ function registerTSNode(root: string) {
 
 function loadTSConfig(root: string): TSConfig | undefined {
   const tsconfigPath = path.join(root, 'tsconfig.json')
-  if (fs.existsSync(tsconfigPath) && parseConfigFileTextToJson) {
-    const tsconfig = parseConfigFileTextToJson(
+  if (fs.existsSync(tsconfigPath) && typescript) {
+    const tsconfig = typescript.parseConfigFileTextToJson(
       tsconfigPath,
       fs.readFileSync(tsconfigPath, 'utf8')
     ).config

--- a/src/ts-node.ts
+++ b/src/ts-node.ts
@@ -2,22 +2,21 @@ import * as fs from 'fs'
 import * as path from 'path'
 import * as TSNode from 'ts-node'
 
-let parseConfigFileTextToJson
+import Debug from './debug'
+const debug = Debug()
+
+let parseConfigFileTextToJson: any = null
 try {
   // Lazy-require 'typescript' to support JavaScript @oclif projects.
   ({parseConfigFileTextToJson} = require('typescript'))
-} catch(ex) {
+} catch (ex) {
   // Ignore errors
+  debug('Cannot find typescript', ex)
 }
-
-
-import Debug from './debug'
 
 const tsconfigs: {[root: string]: TSConfig} = {}
 const rootDirs: string[] = []
 const typeRoots = [`${__dirname}/../node_modules/@types`]
-
-const debug = Debug()
 
 export interface TSConfig {
   compilerOptions: {

--- a/src/ts-node.ts
+++ b/src/ts-node.ts
@@ -2,6 +2,15 @@ import * as fs from 'fs'
 import * as path from 'path'
 import * as TSNode from 'ts-node'
 
+let parseConfigFileTextToJson
+try {
+  // Lazy-require 'typescript' to support JavaScript @oclif projects.
+  ({parseConfigFileTextToJson} = require('typescript'))
+} catch(ex) {
+  // Ignore errors
+}
+
+
 import Debug from './debug'
 
 const tsconfigs: {[root: string]: TSConfig} = {}
@@ -59,9 +68,7 @@ function registerTSNode(root: string) {
 
 function loadTSConfig(root: string): TSConfig | undefined {
   const tsconfigPath = path.join(root, 'tsconfig.json')
-  if (fs.existsSync(tsconfigPath)) {
-    // Lazy-require 'typescript' to support JavaScript @oclif projects.
-    const {parseConfigFileTextToJson} = require('typescript')
+  if (fs.existsSync(tsconfigPath) && parseConfigFileTextToJson) {
     const tsconfig = parseConfigFileTextToJson(
       tsconfigPath,
       fs.readFileSync(tsconfigPath, 'utf8')

--- a/src/ts-node.ts
+++ b/src/ts-node.ts
@@ -1,7 +1,6 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import * as TSNode from 'ts-node'
-import {parseConfigFileTextToJson} from 'typescript'
 
 import Debug from './debug'
 
@@ -61,6 +60,8 @@ function registerTSNode(root: string) {
 function loadTSConfig(root: string): TSConfig | undefined {
   const tsconfigPath = path.join(root, 'tsconfig.json')
   if (fs.existsSync(tsconfigPath)) {
+    // Lazy-require 'typescript' to support JavaScript @oclif projects.
+    const {parseConfigFileTextToJson} = require('typescript')
     const tsconfig = parseConfigFileTextToJson(
       tsconfigPath,
       fs.readFileSync(tsconfigPath, 'utf8')

--- a/yarn.lock
+++ b/yarn.lock
@@ -121,10 +121,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@^10.12.19":
-  version "10.12.19"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.19.tgz#ca1018c26be01f07e66ac7fefbeb6407e4490c61"
-  integrity sha512-2NVovndCjJQj6fUUn9jCgpP4WSqr+u1SoUZMZyJkhGeBFsm6dE46l31S7lPUYt9uQ28XI+ibrJA1f5XyH5HNtA==
+"@types/node@*", "@types/node@^10.12.20":
+  version "10.12.20"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.20.tgz#f79f959acd3422d0889bd1ead1664bd2d17cd367"
+  integrity sha512-9spv6SklidqxevvZyOUGjZVz4QRXGu2dNaLyXIFzFYZW0AGDykzPRIUFJXTlQXyfzAucddwTcGtJNim8zqSOPA==
 
 "@types/proxyquire@^1.3.28":
   version "1.3.28"


### PR DESCRIPTION
> Regression introduced by #70. 

This is blocking. Currently any fresh install of a pure JavaScript `@oclif` project will die with:

```
Cannot find module 'typescript'
```

1. No stack trace.
2. No helpful message.
3. Zip. Zilch. Zero.

Debugging aside, this is due to the fact that these JavaScript projects have no need to have `typescript` in the `dependencies` or `devDependencies` of their `package.json`. 

**Solution:** since `src/ts-node.js` appears to exist to load TypeScript definitions for plugins and other modules consumed by a given CLI project using `@oclif` we only require `typescript` when we have confirmed that a `tsconfig.json` exists within that directory. 

Not sure the right approach to test this, but hopefully we can land a hotfix and then discuss testability / debuggability separately.  