### PR TITLE
Fix process.emitWarning usage

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -447,17 +447,42 @@ export class Config implements IConfig {
     }))
   }
 
-  protected warn(err: {name: string, detail: string}, scope?: string) {
+  protected warn(err: string | Error | {name: string, detail: string}, scope?: string) {
     if (this.warned) return
-    const errorDetails = compact([
-      `${err.name} Plugin: ${this.name}`,
-      err.detail, `module: ${this._base}`,
+
+    if (typeof err === 'string') {
+      process.emitWarning(err)
+      return
+    }
+
+    if (err instanceof Error) {
+      const modifiedErr: any = err
+      modifiedErr.name = `${err.name} Plugin: ${this.name}`
+      modifiedErr.detail = compact([
+        (err as any).detail,
+        `module: ${this._base}`,
+        scope && `task: ${scope}`,
+        `plugin: ${this.name}`,
+        `root: ${this.root}`,
+        'See more details with DEBUG=*'
+      ]).join('\n')
+      process.emitWarning(err)
+      return
+    }
+
+    // err is an object
+    process.emitWarning('Config.warn expected either a string or Error, but instead received an object')
+    err.name = `${err.name} Plugin: ${this.name}`
+    err.detail = compact([
+      err.detail,
+      `module: ${this._base}`,
       scope && `task: ${scope}`,
       `plugin: ${this.name}`,
       `root: ${this.root}`,
       'See more details with DEBUG=*'
     ]).join('\n')
-    process.emitWarning(Error(errorDetails))
+
+    process.emitWarning(JSON.stringify(err))
   }
 }
 export type LoadOptions = Options | string | IConfig | undefined

--- a/src/config.ts
+++ b/src/config.ts
@@ -447,11 +447,17 @@ export class Config implements IConfig {
     }))
   }
 
-  protected warn(err: any, scope?: string) {
+  protected warn(err: {name: string, detail: string}, scope?: string) {
     if (this.warned) return
-    err.name = `${err.name} Plugin: ${this.name}`
-    err.detail = compact([err.detail, `module: ${this._base}`, scope && `task: ${scope}`, `plugin: ${this.name}`, `root: ${this.root}`, 'See more details with DEBUG=*']).join('\n')
-    process.emitWarning(err)
+    const errorDetails = compact([
+      `${err.name} Plugin: ${this.name}`,
+      err.detail, `module: ${this._base}`,
+      scope && `task: ${scope}`,
+      `plugin: ${this.name}`,
+      `root: ${this.root}`,
+      'See more details with DEBUG=*'
+    ]).join('\n')
+    process.emitWarning(Error(errorDetails))
   }
 }
 export type LoadOptions = Options | string | IConfig | undefined


### PR DESCRIPTION
Hello, I'm opening this PR as an initial attempt at a fix for a runtime error that we're seeing on the [Apollo Tooling / CLI](https://github.com/apollographql/apollo-tooling) repo. We've seen some strange behavior in our CI environment / test suite for awhile, and I finally got a reproduction locally - so I dug into the issue.
(See [almost any PR with tests failing on Circle / Azure](https://github.com/apollographql/apollo-tooling/pulls))

## Problem ##
The `any` type on the `err` argument masks a current problem with the usage of Node's `process.emitWarning`. In our case, this _can_ result in a runtime error, but usually doesn't. The error happens [here](https://github.com/nodejs/node/blob/4a07a62d04b219ca72271f7cda0880a2a4300d05/lib/internal/process/warning.js#L118). Because the object being passed to `emitWarning()` is not actually `typeof Error`, this results in an error being thrown by Node. 

## Solution ##
The purpose of this fix is to ensure that whenever `warn()` is called, we pass an actual `Error` to `process.emitWarning()`. I've done my best to ensure no information is lost, however the way the information is passed is slightly different. Though, I believe this function is in a broken state as-is.


While I imagine there are other underlying issues (and this problem exists in multiple places), I'm mostly just making a first attempt to see what your thoughts are on approach and addressing the issue. If you need any more details let me know. I don't know if I can provide a reproduction, as this error is very finnicky and only manifests itself occasionally (usually triggered by an `npm install`).