### PR TITLE
feat: support .tsx files with JSX syntax

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -224,8 +224,8 @@ export class Plugin implements IPlugin {
     }
     this._debug(`loading IDs from ${this.commandsDir}`)
     const patterns = [
-      '**/*.+(js|ts)',
-      '!**/*.+(d.ts|test.ts|test.js|spec.ts|spec.js)',
+      '**/*.+(js|ts|tsx)',
+      '!**/*.+(d.ts|test.ts|test.js|spec.ts|spec.js)?(x)',
     ]
     const ids = globby.sync(patterns, {cwd: this.commandsDir})
     .map(file => {

--- a/src/ts-node.ts
+++ b/src/ts-node.ts
@@ -75,7 +75,7 @@ function registerTSNode(root: string) {
         sourceMap: true,
         rootDirs,
         typeRoots,
-        jsx: "react",
+        jsx: 'react',
       },
     })
   } finally {

--- a/src/ts-node.ts
+++ b/src/ts-node.ts
@@ -75,6 +75,7 @@ function registerTSNode(root: string) {
         sourceMap: true,
         rootDirs,
         typeRoots,
+        jsx: "react",
       },
     })
   } finally {


### PR DESCRIPTION
Fixes https://github.com/oclif/oclif/issues/309

Provides support for `.tsx` files that contain JSX syntax in them in an attempt to make `oclif` compatible with [`ink`](https://github.com/vadimdemedes/ink/) and solve https://github.com/vadimdemedes/ink/issues/239

Configures the pattern discovery in the plugin module to also search for `.tsx` files. Instructs `ts-node` to use "react" mode when dealing with JSX, based on the options in https://www.typescriptlang.org/docs/handbook/jsx.html