### PR TITLE
fix: globby dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@oclif/errors": "^1.0.0",
     "@oclif/parser": "^3.8.0",
     "debug": "^4.1.1",
+    "globby": "^9.2.0",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
@@ -24,7 +25,6 @@
     "eslint-config-oclif": "^3.1.0",
     "eslint-config-oclif-typescript": "^0.1.0",
     "fancy-test": "^1.4.3",
-    "globby": "^9.2.0",
     "lodash": "^4.17.11",
     "mocha": "^6.1.4",
     "proxyquire": "^2.1.0",


### PR DESCRIPTION
Resolves #101 
- Move `globby` to package dependencies. 
- This package `globby` is being used by the package but is only installed in `devDependencies`. As it eventually cascades up to the user's CLI project, it would fail if the user do not have `globby` installed in their `package.json`. It should be a core dependency as per the usage here:
https://github.com/oclif/config/blob/6c800f2966f7d1d5846ca7ffda8955b4b2aa6400/src/plugin.ts#L2

See issue #101 for details.