### PR TITLE
feat(tsconfig): add support for custom typescript config

### DIFF
--- a/src/ts-node.ts
+++ b/src/ts-node.ts
@@ -23,7 +23,7 @@ export interface TSConfig {
 }
 
 function loadTSConfig(root: string): TSConfig | undefined {
-  const tsconfigPath = path.join(root, 'tsconfig.json')
+  const tsconfigPath = path.join(root, process.env.OCLIF_TSCONFIG || 'tsconfig.json')
   let typescript: typeof import('typescript') | undefined
   try {
     typescript = require('typescript')


### PR DESCRIPTION
Hey,

this MR tries to fix https://github.com/oclif/oclif/issues/299 by adding a ENV to set a custom typescript config, nothing special, but enables users to set a custom tsconfig in development scenarios.

Cooler would be to be able to set it inside the oclif config, but as the ts-node module right now doesnt need to access it i didnt want to introduce a "dependency" there.

Let me know how I can improve this MR