### PR TITLE
fix(hooks): match type of Config.runHook to IConfig.runHook

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -304,7 +304,7 @@ export class Config implements IConfig {
     }
   }
 
-  async runHook<T>(event: string, opts: T) {
+  async runHook<T extends Hooks, K extends Extract<keyof T, string>>(event: K, opts: T[K]): Promise<void> {
     debug('start %s hook', event)
     const promises = this.plugins.map(p => {
       const debug = require('debug')([this.bin, p.name, 'hooks', event].join(':'))

--- a/test/typescript.test.ts
+++ b/test/typescript.test.ts
@@ -46,8 +46,7 @@ describe('typescript', () => {
   withConfig
   .stdout()
   .it('runs init hook', async ctx => {
-    // to-do: fix union types
-    await (ctx.config.runHook as any)('init', {id: 'myid', argv: ['foo']})
+    await (ctx.config.runHook)('init', {id: 'myid', argv: ['foo']})
     expect(ctx.stdout).to.equal('running ts init hook\n')
   })
 })


### PR DESCRIPTION
This mismatch was proving tricky to work around over in https://github.com/oclif/dev-cli/pull/141

I’d like to do a little more testing against the other packages that depend upon this before I mark it as ready-for-review.