### PR TITLE
fix: enforce node engine for node lts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "typescript": "3.8.3"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "files": [
     "/lib"


### PR DESCRIPTION
Dependencies in oclif are being bumped and are breaking CLIs using non-supported node versions. To prevent this issues from becoming more widespread it's time to bump the `engines` property for oclif to the minimum LTS supported version.

For more information, see:
* https://github.com/oclif/errors/issues/97
* https://oclif.io/blog/2019/10/31/oclif-node-updates
* https://oclif.io/docs/faqs#why-isnt-node-x-supported