### PR TITLE
feat: add typescript attribute to oclif pjson config

### DIFF
--- a/src/pjson.ts
+++ b/src/pjson.ts
@@ -21,6 +21,7 @@ export namespace PJSON {
       helpClass?: string;
       aliases?: { [name: string]: string | null };
       repositoryPrefix?: string;
+      typescript?: boolean;
       update: {
         s3: S3;
         autoupdate?: {


### PR DESCRIPTION
To explicitly call out a TS project (a backup inference is checked via devDeps)