### PR TITLE
Native ES Module support for Oclif w/ continued support of CommonJS

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -77,7 +77,7 @@ export namespace Command {
   }
 
   export interface Plugin extends Command {
-    load(): Class;
+    load(): Promise<Class>;
   }
 
   // eslint-disable-next-line no-inner-declarations

--- a/src/config.ts
+++ b/src/config.ts
@@ -349,8 +349,7 @@ export class Config implements IConfig {
             context, {...opts as any, config: this})
 
           debug('done')
-        }
-        catch (error) {
+        } catch (error) {
           if (error && error.oclif && error.oclif.exit !== undefined) throw error
           this.warn(error, `runHook ${event}`)
         }

--- a/src/config.ts
+++ b/src/config.ts
@@ -344,6 +344,7 @@ export class Config implements IConfig {
 
           debug('start', p.module ? '(import)' : '(require)', f)
 
+          /* eslint-disable no-await-in-loop */
           await search(p.module ? await importDynamic(f) : require(f)).call(
             context, {...opts as any, config: this})
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -358,49 +358,6 @@ export class Config implements IConfig {
     debug('%s hook done', event)
   }
 
-  // TODO REMOVE: Old runHook method for comparison
-  // async runHook<T>(event: string, opts: T) {
-  //   debug('start %s hook', event)
-  //   const promises = this.plugins.map(p => {
-  //     const debug = require('debug')([this.bin, p.name, 'hooks', event].join(':'))
-  //     const context: Hook.Context = {
-  //       config: this,
-  //       debug,
-  //       exit(code = 0) {
-  //         exit(code)
-  //       },
-  //       log(message?: any, ...args: any[]) {
-  //         process.stdout.write(format(message, ...args) + '\n')
-  //       },
-  //       error(message, options: {code?: string; exit?: number} = {}) {
-  //         error(message, options)
-  //       },
-  //       warn(message: string) {
-  //         warn(message)
-  //       },
-  //     }
-  //     return Promise.all((p.hooks[event] || [])
-  //     .map(async hook => {
-  //       try {
-  //         const f = tsPath(p.root, hook)
-  //         debug('start', f)
-  //         const search = (m: any): Hook<T> => {
-  //           if (typeof m === 'function') return m
-  //           if (m.default && typeof m.default === 'function') return m.default
-  //           return Object.values(m).find((m: any) => typeof m === 'function') as Hook<T>
-  //         }
-  //         await search(require(f)).call(context, {...opts as any, config: this})
-  //         debug('done')
-  //       } catch (error) {
-  //         if (error && error.oclif && error.oclif.exit !== undefined) throw error
-  //         this.warn(error, `runHook ${event}`)
-  //       }
-  //     }))
-  //   })
-  //   await Promise.all(promises)
-  //   debug('%s hook done', event)
-  // }
-
   async runCommand(id: string, argv: string[] = []) {
     debug('runCommand %s %o', id, argv)
     const c = this.findCommand(id)

--- a/src/config.ts
+++ b/src/config.ts
@@ -354,7 +354,7 @@ export class Config implements IConfig {
       await this.runHook('command_not_found', {id})
       throw new CLIError(`command ${id} not found`)
     }
-    const command = c.load()
+    const command = await c.load()
     await this.runHook('prerun', {Command: command, argv})
     const result = await command.run(argv, this)
     await this.runHook('postrun', {Command: command, result: result, argv})

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,8 @@ import {Topic} from './topic'
 import {tsPath} from './ts-node'
 import {compact, flatMap, loadJSON, uniq} from './util'
 
+import importDynamic from './importDynamic'
+
 export type PlatformTypes = 'darwin' | 'linux' | 'win32' | 'aix' | 'freebsd' | 'openbsd' | 'sunos' | 'wsl'
 export type ArchTypes = 'arm' | 'arm64' | 'mips' | 'mipsel' | 'ppc' | 'ppc64' | 's390' | 's390x' | 'x32' | 'x64' | 'x86'
 export interface Options extends Plugin.Options {
@@ -343,7 +345,8 @@ export class Config implements IConfig {
 
           debug('start', p.module ? '(import)' : '(require)', f)
 
-          await search(p.module ? await import(f) : require(f)).call(context, {...opts as any, config: this})
+          await search(p.module ? await importDynamic(f) : require(f)).call(
+           context, {...opts as any, config: this})
 
           debug('done')
         }

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,7 +14,7 @@ import {Topic} from './topic'
 import {tsPath} from './ts-node'
 import {compact, flatMap, loadJSON, uniq} from './util'
 
-import importDynamic from './importDynamic'
+import importDynamic from './import-dynamic'
 
 export type PlatformTypes = 'darwin' | 'linux' | 'win32' | 'aix' | 'freebsd' | 'openbsd' | 'sunos' | 'wsl'
 export type ArchTypes = 'arm' | 'arm64' | 'mips' | 'mipsel' | 'ppc' | 'ppc64' | 's390' | 's390x' | 'x32' | 'x64' | 'x86'
@@ -315,8 +315,7 @@ export class Config implements IConfig {
       return Object.values(m).find((m: any) => typeof m === 'function') as Hook<T>
     }
 
-    for (const p of this.plugins)
-    {
+    for (const p of this.plugins) {
       const debug = require('debug')([this.bin, p.name, 'hooks', event].join(':'))
       const context: Hook.Context = {
         config: this,
@@ -335,7 +334,7 @@ export class Config implements IConfig {
         },
       }
 
-      const hooks = p.hooks[event] || [];
+      const hooks = p.hooks[event] || []
 
       for (const hook of hooks) {
         try {
@@ -346,12 +345,11 @@ export class Config implements IConfig {
           debug('start', p.module ? '(import)' : '(require)', f)
 
           await search(p.module ? await importDynamic(f) : require(f)).call(
-           context, {...opts as any, config: this})
+            context, {...opts as any, config: this})
 
           debug('done')
         }
-        catch (error)
-        {
+        catch (error) {
           if (error && error.oclif && error.oclif.exit !== undefined) throw error
           this.warn(error, `runHook ${event}`)
         }

--- a/src/import-dynamic.ts
+++ b/src/import-dynamic.ts
@@ -4,4 +4,5 @@
  *
  * Simply import and use in the same manner as import().
  */
+/* eslint-disable no-new-func */
 export default new Function('modulePath', 'return import(modulePath)')

--- a/src/import-dynamic.ts
+++ b/src/import-dynamic.ts
@@ -4,4 +4,4 @@
  *
  * Simply import and use in the same manner as import().
  */
-export default new Function('modulePath', 'return import(modulePath)');
+export default new Function('modulePath', 'return import(modulePath)')

--- a/src/importDynamic.ts
+++ b/src/importDynamic.ts
@@ -4,4 +4,4 @@
  *
  * Simply import and use in the same manner as import().
  */
-export default new Function('modulePath', `return import(modulePath)`);
+export default new Function('modulePath', 'return import(modulePath)');

--- a/src/importDynamic.ts
+++ b/src/importDynamic.ts
@@ -1,0 +1,7 @@
+/**
+ * Provides a mechanism to use dynamic import / import() with tsconfig -> module: commonJS as otherwise import() gets
+ * transpiled to require().
+ *
+ * Simply import and use in the same manner as import().
+ */
+export default new Function('modulePath', `return import(modulePath)`);

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -11,7 +11,7 @@ import {Topic} from './topic'
 import {tsPath} from './ts-node'
 import {compact, exists, flatMap, loadJSON, mapValues} from './util'
 
-import importDynamic from './importDynamic'
+import importDynamic from './import-dynamic'
 
 const ROOT_INDEX_CMD_ID = ''
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -191,7 +191,7 @@ export class Plugin implements IPlugin {
     this._debug('reading %s plugin %s', this.type, root)
     this.pjson = await loadJSON(path.join(root, 'package.json')) as any
     this.name = this.pjson.name
-    this.module = this.pjson.type === 'module';
+    this.module = this.pjson.type === 'module'
     const pjsonPath = path.join(root, 'package.json')
     if (!this.name) throw new Error(`no name in ${pjsonPath}`)
     const isProd = hasManifest(path.join(root, 'oclif.manifest.json'))
@@ -323,9 +323,9 @@ export class Plugin implements IPlugin {
       })))
       .filter((f): f is [string, Command] => Boolean(f))
       .reduce((commands, [id, c]) => {
-          commands[id] = c
-          return commands
-        }, {} as {[k: string]: Command}),
+        commands[id] = c
+        return commands
+      }, {} as {[k: string]: Command}),
     }
   }
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -264,10 +264,10 @@ export class Plugin implements IPlugin {
         return Object.values(cmd).find((cmd: any) => typeof cmd.run === 'function')
       }
       const p = require.resolve(path.join(this.commandsDir, ...id.split(':')))
-      this._debug('require', p)
+      this._debug(this.module ? '(import)' : '(require)', p)
       let m
       try {
-        m = require(p)
+        m = this.module ? await import(p) : require(p)
       } catch (error) {
         if (!opts.must && error.code === 'MODULE_NOT_FOUND') return
         throw error

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -11,6 +11,8 @@ import {Topic} from './topic'
 import {tsPath} from './ts-node'
 import {compact, exists, flatMap, loadJSON, mapValues} from './util'
 
+import importDynamic from './importDynamic'
+
 const ROOT_INDEX_CMD_ID = ''
 
 export interface Options {
@@ -267,7 +269,7 @@ export class Plugin implements IPlugin {
       this._debug(this.module ? '(import)' : '(require)', p)
       let m
       try {
-        m = this.module ? await import(p) : require(p)
+        m = this.module ? await importDynamic(p) : require(p)
       } catch (error) {
         if (!opts.must && error.code === 'MODULE_NOT_FOUND') return
         throw error


### PR DESCRIPTION
Greets... 
Please see the associated Issue for pleasantries. 

This pull request updates @oclif/config to support loading of CommonJS & ES Modules (ESM) package plugins for commands and associated hooks. In short a package that has `"type": "module"` set in package.json is treated as an ESM package and dynamic import / import() will be used to load any commands and hooks from that package. It is also possible for the main CLI code to also be ESM. These changes transparently support loading both CommonJS & ESM so plugins in a CLI can be a combination of both.

The usage of dynamic import is gated by checking that package.json type is set to module and if not set then require() is used like the old code. 

The main changes are to `config.ts`, `plugin.ts` and the addition of `import-dynamic.ts`. The latter new source file simply exports a wrapper around import(): `export default new Function('modulePath', 'return import(modulePath)')`. This is necessary as `tsc` when set for `"module": "commonJS"` will transpile import() into require(). I searched for any tsconfig setting that will selectively not transpile import(), but found no configuration based solution. This seems to be the least impactful option and is concise maintaining no changes to tsconfig.json or the build process. I'm certainly open to learning if there is another way to prevent `tsc` from altering dynamic imports in CommonJS targeted output. It should be noted that dynamic imports / import() is available to CommonJS code to load ESM on versions of Node that support `"type": "module"` set in package.json.

The largest flow control change was to `runHook` in `config.ts` which needs to be restructured to support await import() and require in the same block of code. The previous `Promise.all` and `Array.map` code was replaced with synchronous looping with a [single await line](https://github.com/typhonjs-fvtt-scratch/config/blob/master/src/config.ts#L348). This ensures that mixed loading with dynamic import and require executes synchronously. The old `Promise.all` / `Array.map` control flow had execution of hooks out of order (essentially reverse completion / require first) when combining dynamic import and require loading due to the nested anonymous async function in `.map()` with a mixed await `import()` / no await, `require()`, situation. I do believe the new `runHook` code is simpler and captures the intention of loading hooks in order. Each hook starts / finishes before the next one is called. The old code only worked due to the synchronous nature of `require()` and underlying implementation in Node.

For main core CLI code switching to ESM one adds `"type": "module"` to package.json and must change `./bin/run` to `./bin/run.js` so Node can associate it as ESM and add the following to the top of `./bin/run.js`:
```
import { createRequire } from 'module';
const require = createRequire(import.meta.url);
```

Using createRequire is the easiest way to get the bootstrapping code to function correctly and also provides a simple way to switch to ESM. The rest of a CLI codebase can be converted to normal ESM at this point. Any plugins referenced can be a mixture of CommonJS or ESM. 

This is a potential big change and one that is very timely at this point as ESM is increasingly being used on Node. All tests pass and no new tests were added. I tested these changes in my own CLI which I partially converted to ESM while testing, so I was loading a mixture of ESM / CJS plugins before a full conversion to all ESM. It certainly is recommended to test these changes on older versions of Node though the test suite passes on 10.x / 12.x. The usage of dynamic import is only be engaged when `package.json` indicates it should be used and developers are only setting this for Node versions that support it. I only tested my CLI on Node 14.15.1 on OSX and am releasing my CLI requiring Node 14.x+.

My non-trivial CLI test case is `fvttdev` which is published in a pre-alpha but working state:
https://github.com/typhonjs-fvtt/fvttdev
https://www.npmjs.com/package/@typhonjs-fvtt/fvttdev

Integration with an actual demo project using the NPM published version:
https://github.com/typhonjs-fvtt/demo-fvttdev-module

I have posted a separate version of my changes to this repo which can be included directly from Github as a replacement to `@oclif/config`:

https://github.com/typhonjs-node-bundle/oclif-config

For example from `fvttdev` package.json:
https://github.com/typhonjs-fvtt/fvttdev/blob/main/package.json#L15

`"@oclif/config": "typhonjs-node-bundle/oclif-config#main"`

Anyway I look forward to working with any project maintainers to get this update into Oclif. 