### PR TITLE
Native ES Module support for Oclif w/ continued support of CommonJS

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -77,7 +77,7 @@ export namespace Command {
   }
 
   export interface Plugin extends Command {
-    load(): Class;
+    load(): Promise<Class>;
   }
 
   // eslint-disable-next-line no-inner-declarations

--- a/src/import-dynamic.ts
+++ b/src/import-dynamic.ts
@@ -1,0 +1,8 @@
+/**
+ * Provides a mechanism to use dynamic import / import() with tsconfig -> module: commonJS as otherwise import() gets
+ * transpiled to require().
+ *
+ * Simply import and use in the same manner as import().
+ */
+/* eslint-disable no-new-func */
+export const importDynamic = new Function('modulePath', 'return import(modulePath)')

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ try {
 export {IConfig, Config, Options, load, LoadOptions, PlatformTypes, ArchTypes} from './config'
 export {Command} from './command'
 export {Hook, Hooks} from './hooks'
+export {importDynamic} from './import-dynamic'
 export {Manifest} from './manifest'
 export {PJSON} from './pjson'
 export {IPlugin, Plugin} from './plugin'

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -5,6 +5,7 @@ import {inspect} from 'util'
 
 import {Command} from './command'
 import Debug from './debug'
+import {importDynamic} from './import-dynamic'
 import {Manifest} from './manifest'
 import {PJSON} from './pjson'
 import {Topic} from './topic'
@@ -34,6 +35,10 @@ export interface IPlugin {
    * name from package.json
    */
   name: string;
+  /**
+   * type from package.json is set to module
+   */
+  module: boolean;
   /**
    * version from package.json
    *
@@ -70,8 +75,8 @@ export interface IPlugin {
   readonly commandIDs: string[];
   readonly topics: Topic[];
 
-  findCommand(id: string, opts: {must: true}): Command.Class;
-  findCommand(id: string, opts?: {must: boolean}): Command.Class | undefined;
+  findCommand(id: string, opts: {must: true}): Promise<Command.Class>;
+  findCommand(id: string, opts?: {must: boolean}): Promise<Command.Class | undefined>;
   load(): Promise<void>;
 }
 
@@ -140,6 +145,8 @@ export class Plugin implements IPlugin {
 
   name!: string
 
+  module = false
+
   version!: string
 
   pjson!: PJSON.Plugin
@@ -181,6 +188,7 @@ export class Plugin implements IPlugin {
     this._debug('reading %s plugin %s', this.type, root)
     this.pjson = await loadJSON(path.join(root, 'package.json')) as any
     this.name = this.pjson.name
+    this.module = this.pjson.type === 'module'
     const pjsonPath = path.join(root, 'package.json')
     if (!this.name) throw new Error(`no name in ${pjsonPath}`)
     const isProd = hasManifest(path.join(root, 'oclif.manifest.json'))
@@ -198,7 +206,7 @@ export class Plugin implements IPlugin {
 
     this.manifest = await this._manifest(Boolean(this.options.ignoreManifest), Boolean(this.options.errorOnManifestCreate))
     this.commands = Object.entries(this.manifest.commands)
-    .map(([id, c]) => ({...c, load: () => this.findCommand(id, {must: true})}))
+    .map(([id, c]) => ({...c, load: async () => this.findCommand(id, {must: true})}))
     this.commands.sort((a, b) => {
       if (a.id < b.id) return -1
       if (a.id > b.id) return 1
@@ -242,12 +250,12 @@ export class Plugin implements IPlugin {
     return ids
   }
 
-  findCommand(id: string, opts: {must: true}): Command.Class
+  async findCommand(id: string, opts: {must: true}): Promise<Command.Class>
 
-  findCommand(id: string, opts?: {must: boolean}): Command.Class | undefined
+  async findCommand(id: string, opts?: {must: boolean}): Promise<Command.Class | undefined>
 
-  findCommand(id: string, opts: {must?: boolean} = {}): Command.Class | undefined {
-    const fetch = () => {
+  async findCommand(id: string, opts: {must?: boolean} = {}): Promise<Command.Class | undefined> {
+    const fetch = async () => {
       if (!this.commandsDir) return
       const search = (cmd: any) => {
         if (typeof cmd.run === 'function') return cmd
@@ -255,10 +263,10 @@ export class Plugin implements IPlugin {
         return Object.values(cmd).find((cmd: any) => typeof cmd.run === 'function')
       }
       const p = require.resolve(path.join(this.commandsDir, ...id.split(':')))
-      this._debug('require', p)
+      this._debug(this.module ? '(import)' : '(require)', p)
       let m
       try {
-        m = require(p)
+        m = this.module ? await importDynamic(p) : require(p)
       } catch (error) {
         if (!opts.must && error.code === 'MODULE_NOT_FOUND') return
         throw error
@@ -269,7 +277,7 @@ export class Plugin implements IPlugin {
       cmd.plugin = this
       return cmd
     }
-    const cmd = fetch()
+    const cmd = await fetch()
     if (!cmd && opts.must) error(`command ${id} not found`)
     return cmd
   }
@@ -301,15 +309,15 @@ export class Plugin implements IPlugin {
     return {
       version: this.version,
       // eslint-disable-next-line array-callback-return
-      commands: this.commandIDs.map(id => {
+      commands: (await Promise.all(this.commandIDs.map(async id => {
         try {
-          return [id, Command.toCached(this.findCommand(id, {must: true}), this)]
+          return [id, Command.toCached(await this.findCommand(id, {must: true}), this)]
         } catch (error) {
           const scope = 'toCached'
           if (Boolean(errorOnManifestCreate) === false) this.warn(error, scope)
           else throw this.addErrorScope(error, scope)
         }
-      })
+      })))
       .filter((f): f is [string, Command] => Boolean(f))
       .reduce((commands, [id, c]) => {
         commands[id] = c


### PR DESCRIPTION
A pre-announcement edit: While I have initially prototyped ES Module support in Oclif v1 please refer to my modifications to the newly announced Oclif v2 which is where ESM support should be added. You can follow adding ESM to Oclif v2 in @oclif/core:
https://github.com/oclif/core/issues/130

I am closing this pull request for Oclif v1. 

Original message:
----

Greets... 
Please see the associated [Issue](https://github.com/oclif/oclif/issues/521) for pleasantries. 

This pull request updates @oclif/config to support loading of CommonJS & ES Modules (ESM) package plugins for commands and associated hooks. In short a package that has `"type": "module"` set in package.json is treated as an ESM package and dynamic import / import() will be used to load any commands and hooks from that package. It is also possible for the main CLI code to also be ESM. These changes transparently support loading both CommonJS & ESM so plugins in a CLI can be a combination of both.

The usage of dynamic import is gated by checking that package.json type is set to module and if not set then require() is used like the old code. 

The main changes are to `config.ts`, `plugin.ts` and the addition of `import-dynamic.ts`. The latter new source file simply exports a wrapper around import(): `export default new Function('modulePath', 'return import(modulePath)')`. This is necessary as `tsc` when set for `"module": "commonJS"` will transpile import() into require(). I searched for any tsconfig setting that will selectively not transpile import(), but found no configuration based solution. This seems to be the least impactful option and is concise maintaining no changes to tsconfig.json or the build process. I'm certainly open to learning if there is another way to prevent `tsc` from altering dynamic imports in CommonJS targeted output. It should be noted that dynamic imports / import() is available to CommonJS code to load ESM on versions of Node that support `"type": "module"` set in package.json.

The largest flow control change was to `runHook` in `config.ts` which needs to be restructured to support await import() and require in the same block of code. The previous `Promise.all` and `Array.map` code was replaced with synchronous looping with a [single await line](https://github.com/typhonjs-fvtt-scratch/config/blob/master/src/config.ts#L348). This ensures that mixed loading with dynamic import and require executes synchronously. The old `Promise.all` / `Array.map` control flow had execution of hooks out of order (essentially reverse completion / require first) when combining dynamic import and require loading due to the nested anonymous async function in `.map()` with a mixed await `import()` / no await, `require()`, situation. I do believe the new `runHook` code is simpler and captures the intention of loading hooks in order. Each hook starts / finishes before the next one is called. The old code only worked due to the synchronous nature of `require()` and underlying implementation in Node.

For main core CLI code switching to ESM one adds `"type": "module"` to package.json and must change `./bin/run` to `./bin/run.js` so Node can associate it as ESM and add the following to the top of `./bin/run.js`:
```
import { createRequire } from 'module';
const require = createRequire(import.meta.url);
```

Using createRequire is the easiest way to get the bootstrapping code to function correctly and also provides a simple way to switch to ESM. The rest of a CLI codebase can be converted to normal ESM at this point. Any plugins referenced can be a mixture of CommonJS or ESM. 

This is a potential big change and one that is very timely at this point as ESM is increasingly being used on Node. All tests pass and no new tests were added. I tested these changes in my own CLI which I partially converted to ESM while testing, so I was loading a mixture of ESM / CJS plugins before a full conversion to all ESM. It certainly is recommended to test these changes on older versions of Node though the test suite passes on 10.x / 12.x. The usage of dynamic import is only be engaged when `package.json` indicates it should be used and developers are only setting this for Node versions that support it. I only tested my CLI on Node 14.15.1 on OSX and am releasing my CLI requiring Node 14.x+.

My non-trivial CLI test case is `fvttdev` which is published in a pre-alpha but working state:
https://github.com/typhonjs-fvtt/fvttdev
https://www.npmjs.com/package/@typhonjs-fvtt/fvttdev

Integration with an actual demo project using the NPM published version:
https://github.com/typhonjs-fvtt/demo-fvttdev-module

I have posted a separate version of my changes to this repo which can be included directly from Github as a replacement to `@oclif/config`:

https://github.com/typhonjs-oclif/config

For example from `fvttdev` package.json:
https://github.com/typhonjs-fvtt/fvttdev/blob/main/package.json#L15

`"@oclif/config": "git+https://github.com/typhonjs-oclif/config.git"`

Anyway I look forward to working with any project maintainers to get this update into Oclif. 

----------

I have also made modifications to @oclif/command & @oclif/plugin-help to be able to load custom help classes as an ES Module and have tested it along with making sure the test suite passes. I haven't submitted them as PRs as there is a co-dependency between these two modules so the tests would fail unless both of these modules are updated. 

The last concern about updating Oclif to support ES Modules natively regards @oclif/dev-cli and particularly the readme command as it invokes the help class. I would be glad to make the modifications necessary to @oclif/dev-cli when I make contact with any project maintainers regarding the willingness to accept support for ES Modules. 

All my forks have a long term home in the [typhonjs-oclif-scratch](https://github.com/typhonjs-oclif-scratch) Github organization. I do hope to make contact with project maintainers, but am also preparing for things to take a while. 