### PR TITLE
feat: Add support for Custom tsconfig.json, Resolve extended configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "mocha": "^8.2.1",
     "proxyquire": "^2.1.0",
     "ts-node": "^9.0.0",
-    "typescript": "3.8.3"
+    "typescript": "4.2.3"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/src/config.ts
+++ b/src/config.ts
@@ -247,18 +247,18 @@ export class Config implements IConfig {
     s3.templates = {
       ...s3.templates,
       target: {
+        ...s3.templates && s3.templates.target,
         baseDir: '<%- bin %>',
         unversioned: "<%- channel === 'stable' ? '' : 'channels/' + channel + '/' %><%- bin %>-<%- platform %>-<%- arch %><%- ext %>",
         versioned: "<%- channel === 'stable' ? '' : 'channels/' + channel + '/' %><%- bin %>-v<%- version %>/<%- bin %>-v<%- version %>-<%- platform %>-<%- arch %><%- ext %>",
         manifest: "<%- channel === 'stable' ? '' : 'channels/' + channel + '/' %><%- platform %>-<%- arch %>",
-        ...s3.templates && s3.templates.target,
       },
       vanilla: {
+        ...s3.templates && s3.templates.vanilla,
         unversioned: "<%- channel === 'stable' ? '' : 'channels/' + channel + '/' %><%- bin %><%- ext %>",
         versioned: "<%- channel === 'stable' ? '' : 'channels/' + channel + '/' %><%- bin %>-v<%- version %>/<%- bin %>-v<%- version %><%- ext %>",
         baseDir: '<%- bin %>',
         manifest: "<%- channel === 'stable' ? '' : 'channels/' + channel + '/' %>version",
-        ...s3.templates && s3.templates.vanilla,
       },
     }
 
@@ -327,7 +327,7 @@ export class Config implements IConfig {
       return Promise.all((p.hooks[event] || [])
       .map(async hook => {
         try {
-          const f = tsPath(p.root, hook)
+          const f = tsPath(p.root, hook, this.pjson.oclif.tsConfig)
           debug('start', f)
           const search = (m: any): Hook<T> => {
             if (typeof m === 'function') return m

--- a/src/pjson.ts
+++ b/src/pjson.ts
@@ -1,8 +1,9 @@
 export interface PJSON {
   [k: string]: any;
-  dependencies?: {[name: string]: string};
+  dependencies?: { [name: string]: string };
   oclif: {
     schema?: number;
+    tsConfig?: string;
   };
 }
 
@@ -14,7 +15,7 @@ export namespace PJSON {
       schema?: number;
       title?: string;
       description?: string;
-      hooks?: { [name: string]: (string | string[]) };
+      hooks?: { [name: string]: string | string[] };
       commands?: string;
       plugins?: string[];
       devPlugins?: string[];
@@ -76,10 +77,14 @@ export namespace PJSON {
   export interface User extends PJSON {
     private?: boolean;
     oclif: PJSON['oclif'] & {
-      plugins?: (string | PluginTypes.User | PluginTypes.Link)[]; };
+      plugins?: (string | PluginTypes.User | PluginTypes.Link)[];
+    };
   }
 
-  export type PluginTypes = PluginTypes.User | PluginTypes.Link | {root: string}
+  export type PluginTypes =
+    | PluginTypes.User
+    | PluginTypes.Link
+    | { root: string };
   export namespace PluginTypes {
     export interface User {
       type: 'user';

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -211,7 +211,7 @@ export class Plugin implements IPlugin {
   }
 
   get commandsDir() {
-    return tsPath(this.root, this.pjson.oclif.commands)
+    return tsPath(this.root, this.pjson.oclif.commands, this.pjson.oclif.tsConfig)
   }
 
   get commandIDs() {

--- a/test/fixtures/typescript/tsconfig.custom.json
+++ b/test/fixtures/typescript/tsconfig.custom.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json"
+}
+  

--- a/test/test.ts
+++ b/test/test.ts
@@ -5,6 +5,7 @@ import * as Config from '../src'
 export const fancy = base
 .register('resetConfig', () => ({
   run(ctx: {config: Config.IConfig}) {
+    // @ts-expect-error
     delete ctx.config
   },
 }))

--- a/test/ts-node.test.ts
+++ b/test/ts-node.test.ts
@@ -2,7 +2,7 @@ import * as path from 'path'
 import * as proxyquire from 'proxyquire'
 import * as tsNode from 'ts-node'
 
-import {TSConfig} from '../src/ts-node'
+import {TSConfig, tsPath} from '../src/ts-node'
 
 import {expect, fancy} from './test'
 
@@ -37,6 +37,11 @@ describe('tsPath', () => {
   withMockTsConfig()
   .it('should resolve a .ts file', ctx => {
     const result = ctx.tsNodePlugin.tsPath(root, orig)
+    expect(result).to.equal(path.join(root, orig))
+  })
+
+  it('should resolve a .ts file using custom config using "extends"', () => {
+    const result = tsPath(root, orig, 'tsconfig.custom.json')
     expect(result).to.equal(path.join(root, orig))
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1706,11 +1706,10 @@ lodash.zip@^4.2.0:
   resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
   integrity sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=
 
-lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20:
+lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.20:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
 
 log-symbols@4.0.0:
   version "4.0.0"
@@ -2776,10 +2775,10 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
+  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
 
 uglify-js@^3.1.4:
   version "3.7.3"


### PR DESCRIPTION
This addresses both https://github.com/oclif/oclif/issues/299 and https://github.com/oclif/oclif/issues/488

`loadTSConfig()` in `src/ts-node.ts` was not properly resolving extended configuration files, because while `parseConfigFileTextToJson` will load and parse a given `tsconfig.json` file, it does not merge compilerOptions from configs specified in the `extends` option.

This implementation is based on the solutions suggested in https://github.com/microsoft/TypeScript/issues/5276
and https://stackoverflow.com/questions/53804566/how-to-get-compileroptions-from-tsconfig-json which rely on Typescript's utilities for loading and parsing `tsconfig.json` files.

Specifically, by adding  a call to `parseJsonConfigFileContent()`,  the merged compilerOptions will be resolved as expected.

Additionally, this adds support for user-defined tsconfig files through the `tsConfig` option under `oclif` key in their `package.json`.